### PR TITLE
Changes for 2.7

### DIFF
--- a/ContentScript.js
+++ b/ContentScript.js
@@ -8,8 +8,6 @@
     
     var Elements = new Set();
     var State = null;
-    var Visibility = null;
-    var pictureinpicture = false;
     
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
@@ -146,18 +144,6 @@
         if (src instanceof HTMLMediaElement) {
             onPlay(src, event.isTrusted);
             Elements.add(src);
-	    src.addEventListener('enterpictureinpicture', event => {
-	        pictureinpicture = true;
-	        checkVisibility();
-	    }, {
-                passive: true
-	    });
-	    src.addEventListener('leavepictureinpicture', event => {
-	        pictureinpicture = false;
-		checkVisibility();
-            }, {
-                passive: true
-            });
         }
     }, {
         capture: true,
@@ -173,25 +159,6 @@
         capture: true,
         passive: true
     });
-    
-    function checkVisibility() {
-        let result;
-        if (document.visibilityState == 'hidden' && !pictureinpicture) {
-            result = "hidden";
-        } else {
-            result = "shown";
-        }
-        if (result !== Visibility) {
-            Visibility = result;
-            chrome.runtime.sendMessage(Visibility);
-        }
-    }
-    
-    window.addEventListener('visibilitychange', checkVisibility, {
-        capture: true,
-        passive: true
-    });
-    
 
     window.addEventListener('pause', event => {
         setTimeout(() => {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -110,8 +110,9 @@
     function onPlay(e, trusted = false) {
         if (e.muted) {
             send('playMuted');
-        } else if (trusted) {
+        } else if (trusted) {   
             send('playTrusted');
+	    normalPlayback(e);
         } else {
             send('play');
         }

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -32,7 +32,7 @@
         case 'play':
             // When there media already playing tell the background script.
             if (isPlaying())
-                chrome.runtime.sendMessage('play');
+                send('play');
             resume(true);
             break
         }

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -8,6 +8,7 @@
     
     var Elements = new Set();
     var State = null;
+    var Visibility = null;
     
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
@@ -243,6 +244,23 @@
             normalPlayback(e);
         });
     }
+    
+    function checkVisibility() {
+        if (document.visibilityState == 'hidden') {
+            result = "hidden";
+        } else {
+            result = "shown";
+        }
+        if (result !== Visibility) {
+            Visibility = result;
+            chrome.runtime.sendMessage(Visibility);
+        }
+    }
 
+    window.addEventListener('visibilitychange', checkVisibility, {
+        capture: true,
+        passive: true
+    });
+    
     // End of code
 })();

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -144,7 +144,7 @@
     window.addEventListener('volumechange', function (event) {
         const src = event.srcElement;
         if (src instanceof HTMLMediaElement && !isPaused(src)) {
-            onPlay(src);
+            onPlay(src, event.isTrusted);
         }
     }, {
         capture: true,
@@ -194,7 +194,7 @@
                 event.stopPropagation();
             }
             if (!isPaused(src)) {
-                onPlay(src);
+                onPlay(src, event.isTrusted);
             }
         }
     }, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -245,8 +245,9 @@
     }
     
     function checkVisibility() {
-        let state = (document.visibilityState == 'hidden') ? 'hidden' : "visible";
-	chrome.runtime.sendMessage(state);
+        if (document.visibilityState == 'hidden') {
+		chrome.runtime.sendMessage('hidden');
+	}	
     }
 
     window.addEventListener('visibilitychange', checkVisibility, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -245,9 +245,9 @@
     }
     
     function checkVisibility() {
-        if (document.visibilityState == 'hidden') {
+        if (document.visibilityState == 'hidden' && !document.pictureInPictureElement) {
 		chrome.runtime.sendMessage('hidden');
-	}	
+	}
     }
 
     window.addEventListener('visibilitychange', checkVisibility, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -8,7 +8,6 @@
     
     var Elements = new Set();
     var State = null;
-    var Visibility = null;
     
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
@@ -246,15 +245,8 @@
     }
     
     function checkVisibility() {
-        if (document.visibilityState == 'hidden') {
-            result = "hidden";
-        } else {
-            result = "shown";
-        }
-        if (result !== Visibility) {
-            Visibility = result;
-            chrome.runtime.sendMessage(Visibility);
-        }
+        let state = (document.visibilityState == 'hidden') ? 'hidden' : "visible";
+		chrome.runtime.sendMessage(state);
     }
 
     window.addEventListener('visibilitychange', checkVisibility, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -9,6 +9,7 @@
     var Elements = new Set();
     var State = null;
     var Visibility = null;
+    var pictureinpicture = false;
     
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
@@ -163,7 +164,7 @@
     
     function checkVisibility() {
         let result;
-        if (document.visibilityState == 'hidden' && !document.pictureInPictureElement) {
+        if (document.visibilityState == 'hidden' && !pictureinpicture) {
             result = "hidden";
         } else {
             result = "shown";
@@ -179,12 +180,18 @@
         passive: true
     });
     
-    window.addEventListener('leavepictureinpicture', checkVisibility, {
+    window.addEventListener('leavepictureinpicture', event => {
+        pictureinpicture = false;
+        checkVisibility();
+    }, {
         capture: true,
         passive: true
     });
     
-    window.addEventListener('enterpictureinpicture', checkVisibility, {
+    window.addEventListener('enterpictureinpicture', event => {
+        pictureinpicture = true;
+        checkVisibility();
+    }, {
         capture: true,
         passive: true
     });

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -7,25 +7,16 @@
     if (hasProperty(window, "Elements")) return
     
     var Elements = new Set();
-    var tabMuted;
 	
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
-	case 'mute':
-            tabMuted = true;
-            checkVisibility();
-            if (isPlaying())
-                send('playMuted');
-            break
-        case 'unmute':
-            tabMuted = false;
-            if (isPlaying())
-                send('play');
-            break
+		case 'pausemuted':
+			checkVisibility();
+			break
         case 'toggleFastPlayback':
             toggleRate();
             break
-	case 'Rewind':
+        case 'Rewind':
             Rewind();
             break
         case 'togglePlayback':
@@ -132,7 +123,7 @@
 
     
     function onPlay(e, trusted = false) {
-        if (e.muted || tabMuted) {
+        if (e.muted) {
             send('playMuted');
         } else if (trusted) {   
             send('playTrusted');

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -43,8 +43,7 @@
 
     function togglePlayback() {
         Elements.forEach(e => {
-            if (e.paused)
-                return;
+            if (e.paused) return;
             if (e.togglePause) {
                 e.togglePause = false;
                 e.playbackRate = e.wasPlaybackRate;

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -246,7 +246,7 @@
     
     function checkVisibility() {
         let state = (document.visibilityState == 'hidden') ? 'hidden' : "visible";
-		chrome.runtime.sendMessage(state);
+	chrome.runtime.sendMessage(state);
     }
 
     window.addEventListener('visibilitychange', checkVisibility, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -112,6 +112,7 @@
         if (e.muted) {
             send('playMuted');
         } else if (trusted) {
+	    normalPlayback(e);
             send('playTrusted');
         } else {
             send('play');

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -146,18 +146,18 @@
         if (src instanceof HTMLMediaElement) {
             onPlay(src, event.isTrusted);
             Elements.add(src);
-			src.addEventListener('enterpictureinpicture ', event => {
-				pictureinpicture = true;
-				checkVisibility();
-			}, {
-				passive: true
-			});
-			src.addEventListener('leavepictureinpicture', event => {
-				pictureinpicture = false;
-				checkVisibility();
-			}, {
-				passive: true
-			});
+	    src.addEventListener('enterpictureinpicture', event => {
+	        pictureinpicture = true;
+	        checkVisibility();
+	    }, {
+                passive: true
+	    });
+	    src.addEventListener('leavepictureinpicture', event => {
+	        pictureinpicture = false;
+		checkVisibility();
+            }, {
+                passive: true
+            });
         }
     }, {
         capture: true,

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -68,16 +68,14 @@
 
     function next() {
         Elements.forEach(e => {
-            if (isPaused(e))
-                return;
+            if (isPaused(e)) return;
             e.currentTime = e.duration;
         });
     }
 
     function previous() {
         Elements.forEach(e => {
-            if (isPaused(e))
-                return;
+            if (isPaused(e)) return;
             // Unknown
             e.currentTime = 0;
         });

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -10,9 +10,9 @@
 	
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
-		case 'pausemuted':
-			checkVisibility();
-			break
+	case 'pausemuted':
+            checkVisibility();
+            break
         case 'toggleFastPlayback':
             toggleRate();
             break

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -159,6 +159,27 @@
         capture: true,
         passive: true
     });
+    
+    window.addEventListener('leavepictureinpicture', function (event) {
+        const src = event.srcElement;
+        if (src instanceof HTMLMediaElement && !isPaused(src)) {
+            onPlay(src, event.isTrusted);
+        }
+    }, {
+        capture: true,
+        passive: true
+    });
+    
+    window.addEventListener('enterpictureinpicture', function (event) {
+        const src = event.srcElement;
+        // Even if the media is muted and tab is inactive dont pause it if its visable.
+        if (src instanceof HTMLMediaElement && !isPaused(src) && event.isTrusted) {
+            send("playTrusted");
+        }
+    }, {
+        capture: true,
+        passive: true
+    });
 
     window.addEventListener('pause', event => {
         setTimeout(() => {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -7,7 +7,8 @@
     if (hasProperty(window, "Elements")) return
     
     var Elements = new Set();
-
+    var State = null;
+    
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
         case 'toggleFastPlayback':
@@ -107,6 +108,7 @@
     }
 
     function onPlay(e, trusted = false) {
+        if (State === "playing") return
         if (e.muted) {
             chrome.runtime.sendMessage('playMuted');
         } else if (trusted) {
@@ -114,6 +116,7 @@
         } else {
             chrome.runtime.sendMessage('play');
         }
+        State = "playing";
     }
 
     window.addEventListener('DOMContentLoaded', () => {
@@ -173,8 +176,10 @@
             // Check if all elements have paused.
             Elements.delete(src);
             normalPlayback(src);
-            if (!isPlaying())
+            if (!isPlaying() && State === "playing") {
                 chrome.runtime.sendMessage('pause');
+                State = "paused";
+            }
         }
     }
 

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -182,7 +182,7 @@
             // Check if all elements have paused.
             Elements.delete(src);
             normalPlayback(src);
-            if (!isPlaying() && State === "playing") {
+            if (!isPlaying()) {
                 send('pause');
             }
         }

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -4,10 +4,9 @@
 (() => {
     // Script should only run once
 
-    if (hasProperty(window, "Elements"))
-        return
-
-        var Elements = new Set();
+    if (hasProperty(window, "Elements")) return
+    
+    var Elements = new Set();
 
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
@@ -217,8 +216,7 @@
 
     async function pause() {
         Elements.forEach(e => {
-            if (isPaused(e))
-                return;
+            if (isPaused(e)) return;
             pauseElement(e);
         });
     }
@@ -229,11 +227,10 @@
                 Elements.delete(e);
                 return
             }
-            if (!e.wasPlaying)
-                return
-                // Pause foreground media normaly
-                if (shouldPlay === false)
-                    e.pause();
+            if (!e.wasPlaying) return
+            // Pause foreground media normaly
+            if (shouldPlay === false)
+                e.pause();
             normalPlayback(e);
         });
     }

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -7,9 +7,21 @@
     if (hasProperty(window, "Elements")) return
     
     var Elements = new Set();
-    
+    var tabMuted;
+	
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
+	case 'mute':
+            tabMuted = true;
+            checkVisibility();
+            if (isPlaying())
+                send('playMuted');
+            break
+        case 'unmute':
+            tabMuted = false;
+            if (isPlaying())
+                send('play');
+            break
         case 'toggleFastPlayback':
             toggleRate();
             break
@@ -120,7 +132,7 @@
 
     
     function onPlay(e, trusted = false) {
-        if (e.muted) {
+        if (e.muted || tabMuted) {
             send('playMuted');
         } else if (trusted) {   
             send('playTrusted');

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -7,7 +7,6 @@
     if (hasProperty(window, "Elements")) return
     
     var Elements = new Set();
-    var State = null;
     
     chrome.runtime.onMessage.addListener(message => {
         switch (message) {
@@ -112,17 +111,14 @@
         if (e.muted) {
             send('playMuted');
         } else if (trusted) {
-            chrome.runtime.sendMessage('playTrusted');
+            send('playTrusted');
         } else {
             send('play');
         }
     }
 
     function send(message) {
-        if (State !== message) {
-            chrome.runtime.sendMessage(message);
-            State = message;
-        }
+	    chrome.runtime.sendMessage(message);
     }
     
     window.addEventListener('DOMContentLoaded', () => {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -107,18 +107,24 @@
         }
     }
 
+    
     function onPlay(e, trusted = false) {
-        if (State === "playing") return
         if (e.muted) {
-            chrome.runtime.sendMessage('playMuted');
+            send('playMuted');
         } else if (trusted) {
-            chrome.runtime.sendMessage('playTrusted');
+            send('playTrusted');
         } else {
-            chrome.runtime.sendMessage('play');
+            send('play');
         }
-        State = "playing";
     }
 
+    function send(message) {
+        if (State !== message) {
+            chrome.runtime.sendMessage(message);
+            State = message;
+        }
+    }
+    
     window.addEventListener('DOMContentLoaded', () => {
         // Adds content to DOM needed because of isolation
         injectScript('WindowScript.js');
@@ -127,7 +133,7 @@
     });
 
     window.addEventListener('pagehide', () => {
-        chrome.runtime.sendMessage('pause');
+        send('pause');
     }, {
         passive: true
     });
@@ -177,8 +183,7 @@
             Elements.delete(src);
             normalPlayback(src);
             if (!isPlaying() && State === "playing") {
-                chrome.runtime.sendMessage('pause');
-                State = "paused";
+                send('pause');
             }
         }
     }

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -112,8 +112,7 @@
         if (e.muted) {
             send('playMuted');
         } else if (trusted) {
-	    normalPlayback(e);
-            send('playTrusted');
+            chrome.runtime.sendMessage('playTrusted');
         } else {
             send('play');
         }

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -146,6 +146,18 @@
         if (src instanceof HTMLMediaElement) {
             onPlay(src, event.isTrusted);
             Elements.add(src);
+			src.addEventListener('enterpictureinpicture ', event => {
+				pictureinpicture = true;
+				checkVisibility();
+			}, {
+				passive: true
+			});
+			src.addEventListener('leavepictureinpicture', event => {
+				pictureinpicture = false;
+				checkVisibility();
+			}, {
+				passive: true
+			});
         }
     }, {
         capture: true,
@@ -180,21 +192,6 @@
         passive: true
     });
     
-    window.addEventListener('leavepictureinpicture', event => {
-        pictureinpicture = false;
-        checkVisibility();
-    }, {
-        capture: true,
-        passive: true
-    });
-    
-    window.addEventListener('enterpictureinpicture', event => {
-        pictureinpicture = true;
-        checkVisibility();
-    }, {
-        capture: true,
-        passive: true
-    });
 
     window.addEventListener('pause', event => {
         setTimeout(() => {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -162,7 +162,7 @@
     window.addEventListener('volumechange', function (event) {
         const src = event.srcElement;
         if (src instanceof HTMLMediaElement && !isPaused(src)) {
-            onPlay(src, event.isTrusted);
+            onPlay(src);
         }
     }, {
         capture: true,
@@ -213,7 +213,7 @@
                 event.stopPropagation();
             }
             if (!isPaused(src)) {
-                onPlay(src, event.isTrusted);
+                onPlay(src);
             }
         }
     }, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -106,9 +106,11 @@
         }
     }
 
-    function onPlay(e) {
+    function onPlay(e, trusted = false) {
         if (e.muted) {
             chrome.runtime.sendMessage('playMuted');
+        } else if (trusted) {
+            chrome.runtime.sendMessage('playTrusted');
         } else {
             chrome.runtime.sendMessage('play');
         }
@@ -131,7 +133,7 @@
     window.addEventListener('play', function (event) {
         const src = event.srcElement;
         if (src instanceof HTMLMediaElement) {
-            onPlay(src);
+            onPlay(src, event.isTrusted);
             Elements.add(src);
         }
     }, {

--- a/ContentScript.js
+++ b/ContentScript.js
@@ -13,6 +13,9 @@
         case 'toggleFastPlayback':
             toggleRate();
             break
+	case 'Rewind':
+            Rewind();
+            break
         case 'togglePlayback':
             togglePlayback();
             break
@@ -91,6 +94,15 @@
                 e.wasPlaybackRate = e.playbackRate;
                 e.playbackRate = 2;
             }
+        });
+    }
+
+    // Controlled by global rewind shortcut
+    function Rewind() {
+        Elements.forEach(e => {
+            if (isPaused(e))
+                return;
+	    e.currentTime -= 30;
         });
     }
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ Features:
 - Global Fast forward
 - Mark tab for automatic resume
 - Custom media controls for play, pause, next, previous
+- Shortcut to mark a tab as ignored.
+- Shortcut to rewind media in 30 second increments.
+- Option to pause media when muted and not visible (Also supports tab mute, Not PiP due to lack of API on firefox)

--- a/background.js
+++ b/background.js
@@ -34,6 +34,8 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     switch (message) {
         case 'hidden':
             visableTabs.delete(sender.tab.id);
+            // Pause inactive muted tabs.
+            chrome.tabs.sendMessage(sender.tab.id, "pause");
             break
         case 'shown':
             visableTabs.add(sender.tab.id);
@@ -98,9 +100,6 @@ function tabChange(tab) {
         // Pause all except active tab
         Broadcast('pause', tab.id);
     }
-
-    // Pause inactive muted tabs.
-    Broadcast('pause', tab.id, mutedTabs);
 
     if (media.has(tab.id) || mutedTabs.has(tab.id)) {
         play(tab.id);
@@ -255,8 +254,6 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 async function Broadcast(message, exclude = false, tabs = media) {
     tabs.forEach(id => { // Only for tabs that have had media.
         if (id === exclude || id === lastPlaying) return
-        // Dont pause muted media thats visible.
-        if (message === "pause" && mutedTabs.has(id) && visableTabs.has(id)) return
         chrome.tabs.sendMessage(id, message);
     });
 };

--- a/background.js
+++ b/background.js
@@ -67,9 +67,9 @@ function onPlay(tab, trusted = false) {
         media.delete(tab.id);
         media.add(tab.id);
     }
-    if (tab.audible) return
     // Pause all other media.
-    Broadcast('pause', tab.id);
+    if (tab.audible)
+        Broadcast('pause', tab.id);   
 }
 
 function onPause(id) {

--- a/background.js
+++ b/background.js
@@ -60,9 +60,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 });
 
 function onPlay(tab, trusted = false) {
-    if (hasProperty(options, 'multipletabs') && tab.id !== activeTab && !trusted) return
+    if (trusted) activeTab = tab.id;
+    if (hasProperty(options, 'multipletabs') && tab.id !== activeTab) return
     // Dont allow a diffrent tab to hijack active media.
-    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id && !trusted) {
+    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id) {
         return Broadcast('pause', activeTab);
     };
     mediaPlaying = tab.id;

--- a/background.js
+++ b/background.js
@@ -32,7 +32,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     if (!hasProperty(sender, 'tab') || ignoredTabs.has(sender.tab.id)) return
     switch (message) {
         case 'hidden':
-            if (mutedTabs.has(sender.tab.id)) {
+            if (mutedTabs.has(sender.tab.id) && hasProperty(options, 'pausemuted')) {
                 // Pause hidden muted tabs.
                 chrome.tabs.sendMessage(sender.tab.id, "pause");
             }

--- a/background.js
+++ b/background.js
@@ -40,6 +40,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
             media.delete(sender.tab.id);
             onPause(sender.tab.id);
             break
+        case 'playTrusted':
+            media.add(sender.tab.id);
+            onPlay(sender.tab, true);
+            break
         case 'pause':
             media.delete(sender.tab.id);
             onPause(sender.tab.id);
@@ -47,14 +51,14 @@ chrome.runtime.onMessage.addListener((message, sender) => {
         }
 });
 
-function onPlay(tab) {
+function onPlay(tab, trusted = false) {
     if (hasProperty(options, 'multipletabs') && tab.id !== activeTab) return
     // Dont allow a diffrent tab to hijack active media.
-    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id) {
+    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id && !trusted) {
         return Broadcast('pause', activeTab);
     };
     mediaPlaying = tab.id;
-    if (tab.id == activeTab)
+    if (tab.id == activeTab || trusted)
         lastPlaying = null;
     if (media.has(tab.id)) {
         mutedTabs.delete(tab.id);

--- a/background.js
+++ b/background.js
@@ -34,8 +34,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     switch (message) {
         case 'hidden':
             visableTabs.delete(sender.tab.id);
+            break
         case 'shown':
             visableTabs.add(sender.tab.id);
+            break
         case 'play':
             media.add(sender.tab.id);
             onPlay(sender.tab);

--- a/background.js
+++ b/background.js
@@ -236,8 +236,8 @@ function remove(tabId) {
 // Detect changes to audible status of tabs
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (ignoredTabs.has(tabId)) return
-    if (hasProperty(changeInfo, 'mutedInfo')) {
-        let muteState =  (changeInfo.mutedInfo.muted) ? 'mute' : "unmute";
+    if (hasProperty(changeInfo, 'mutedInfo') || hasProperty(changeInfo, 'url')) {
+        let muteState =  (tab.muted) ? 'mute' : "unmute";
         chrome.tabs.sendMessage(tabId, muteState);
     }
     if (!hasProperty(changeInfo, 'audible')) return // Bool that contains if audio is playing on tab.

--- a/background.js
+++ b/background.js
@@ -104,10 +104,6 @@ function tabChange(tab) {
     } else if (otherTabs.has(tab.id)) {
         onPlay(tab);
     }
-
-    if (hasProperty(options, 'multipletabs') && !media.has(tab.id)) {
-        autoResume(tab.id);
-    }
 }
 
 function getResumeTab() {

--- a/background.js
+++ b/background.js
@@ -44,8 +44,12 @@ chrome.runtime.onMessage.addListener((message, sender) => {
             }
             break
         case 'play':
-            media.add(sender.tab.id);
-            onPlay(sender.tab);
+            if (sender.tab.muted) {
+                onMute(sender.tab.id);
+            } else {
+                media.add(sender.tab.id);
+                onPlay(sender.tab);
+            }
             break
         case 'playMuted':
             onMute(sender.tab.id);

--- a/background.js
+++ b/background.js
@@ -67,6 +67,7 @@ function onPlay(tab, trusted = false) {
         media.delete(tab.id);
         media.add(tab.id);
     }
+    if (tab.audible) return
     // Pause all other media.
     Broadcast('pause', tab.id);
 }

--- a/background.js
+++ b/background.js
@@ -176,25 +176,13 @@ chrome.commands.onCommand.addListener(async command => {
         toggleOption('pauseoninactive');
         break
     case 'backgroundaudio':
-        chrome.tabs.query({
-            active: true,
-            currentWindow: true
-        }, tabs => {
-            if (tabs.length === 0) return
             // Currently only has one tab
             backgroundaudio.clear();
-            backgroundaudio.add(tabs[0].id);
-        });
+            backgroundaudio.add(activeTab);
         break
     case 'ignoretab':
-        chrome.tabs.query({
-            active: true,
-            currentWindow: true
-        }, tabs => {
-            if (tabs.length === 0) return
-            ignoredTabs.add(tabs[0].id);
-            remove(tabs[0].id);
-        });
+            ignoredTabs.add(activeTab);
+            remove(activeTab);
         break
     }
 });

--- a/background.js
+++ b/background.js
@@ -9,7 +9,6 @@ var lastPlaying = null;
 var otherTabs = new Set(); // Tab IDs of audible tabs with no permission to access.
 var mutedTabs = new Set(); // Tab IDs of muted tabs.
 var ignoredTabs = new Set();
-var visableTabs = new Set(); // Tab IDs of tabs that are visable.
 
 chrome.storage.sync.get('options', result => {
     if (typeof result.options === 'object' && result.options !== null)
@@ -33,12 +32,12 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     if (!hasProperty(sender, 'tab') || ignoredTabs.has(sender.tab.id)) return
     switch (message) {
         case 'hidden':
-            visableTabs.delete(sender.tab.id);
-            // Pause inactive muted tabs.
-            chrome.tabs.sendMessage(sender.tab.id, "pause");
+            if (mutedTabs.has(sender.tab.id)) {
+                // Pause hidden muted tabs.
+                chrome.tabs.sendMessage(sender.tab.id, "pause");
+            }
             break
         case 'shown':
-            visableTabs.add(sender.tab.id);
             break
         case 'play':
             media.add(sender.tab.id);
@@ -233,7 +232,6 @@ function remove(tabId) {
     otherTabs.delete(tabId);
     backgroundaudio.delete(tabId);
     mutedTabs.delete(tabId);
-    visableTabs.delete(tabId);
     onPause(tabId);
 }
 

--- a/background.js
+++ b/background.js
@@ -60,13 +60,14 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 });
 
 function onPlay(tab, trusted = false) {
+    if (trusted) activeTab = tab.id;
     if (hasProperty(options, 'multipletabs') && tab.id !== activeTab) return
     // Dont allow a diffrent tab to hijack active media.
-    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id && !trusted) {
+    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id) {
         return Broadcast('pause', tab.id);
     };
     mediaPlaying = tab.id;
-    if (tab.id == activeTab || trusted)
+    if (tab.id == activeTab)
         lastPlaying = null;
     if (media.has(tab.id)) {
         mutedTabs.delete(tab.id);

--- a/background.js
+++ b/background.js
@@ -37,8 +37,6 @@ chrome.runtime.onMessage.addListener((message, sender) => {
                 chrome.tabs.sendMessage(sender.tab.id, "pause");
             }
             break
-        case 'shown':
-            break
         case 'play':
             media.add(sender.tab.id);
             onPlay(sender.tab);

--- a/background.js
+++ b/background.js
@@ -248,8 +248,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
         if (changeInfo.mutedInfo.muted && media.has(tabId)) {
             if (hasProperty(options, 'pausemuted')) chrome.tabs.sendMessage(tabId, 'pausemuted');
             onMute(tabId);
-		}
-		// If tab gets unmuted resume it.
+        }
+	// If tab gets unmuted resume it.
         else if (!changeInfo.mutedInfo.muted && mutedTabs.has(tabId)) {
             mediaPlaying = tabId;
             chrome.tabs.sendMessage(tabId, 'play');

--- a/background.js
+++ b/background.js
@@ -60,11 +60,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 });
 
 function onPlay(tab, trusted = false) {
-    if (trusted) activeTab = tab.id;
     if (hasProperty(options, 'multipletabs') && tab.id !== activeTab) return
     // Dont allow a diffrent tab to hijack active media.
-    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id) {
-        return Broadcast('pause', activeTab);
+    if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id && !trusted) {
+        return Broadcast('pause', tab.id);
     };
     mediaPlaying = tab.id;
     if (tab.id == activeTab || trusted)

--- a/background.js
+++ b/background.js
@@ -162,8 +162,8 @@ chrome.commands.onCommand.addListener(async command => {
     case 'toggleFastPlayback':
         Broadcast('toggleFastPlayback');
         break
-    case 'toggleFastRewind':
-        Broadcast('toggleFastRewind');
+    case 'Rewind':
+        Broadcast('Rewind');
         break
     case 'togglePlayback':
         var result = getResumeTab();

--- a/background.js
+++ b/background.js
@@ -60,7 +60,7 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 });
 
 function onPlay(tab, trusted = false) {
-    if (hasProperty(options, 'multipletabs') && tab.id !== activeTab) return
+    if (hasProperty(options, 'multipletabs') && tab.id !== activeTab && !trusted) return
     // Dont allow a diffrent tab to hijack active media.
     if (tab.id !== activeTab && tab.id !== lastPlaying && mediaPlaying !== tab.id && !trusted) {
         return Broadcast('pause', activeTab);

--- a/background.js
+++ b/background.js
@@ -162,6 +162,9 @@ chrome.commands.onCommand.addListener(async command => {
     case 'toggleFastPlayback':
         Broadcast('toggleFastPlayback');
         break
+    case 'toggleFastRewind':
+        Broadcast('toggleFastRewind');
+        break
     case 'togglePlayback':
         var result = getResumeTab();
         if (result !== false) {

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -45,7 +45,7 @@
         "description": "Go to start of media"
     },
 	"ignoretab": {
-        "description": "Ignores a tab"
+        "description": "Ignore a tab"
     }
   },
   "permissions": [

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -21,8 +21,8 @@
         },
         "description": "Toggle fast playback"
     },
-    "toggleFastRewind": {
-        "description": "Toggle fast rewind"
+    "Rewind": {
+        "description": "Rewind"
     },
     "pauseoninactive": {
         "suggested_key": {

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -21,6 +21,9 @@
         },
         "description": "Toggle fast playback"
     },
+    "toggleFastRewind": {
+        "description": "Toggle fast rewind"
+    },
     "pauseoninactive": {
         "suggested_key": {
             "default": "Alt+I",
@@ -44,7 +47,7 @@
     "previous": {
         "description": "Go to start of media"
     },
-	"ignoretab": {
+    "ignoretab": {
         "description": "Ignore a tab"
     }
   },

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -25,6 +25,9 @@
         },
         "description": "Toggle fast playback"
     },
+    "toggleFastRewind": {
+        "description": "Toggle fast rewind"
+    },
     "pauseoninactive": {
         "suggested_key": {
             "default": "Alt+I",
@@ -48,7 +51,7 @@
     "previous": {
         "description": "Go to start of media"
     },
-	"ignoretab": {
+    "ignoretab": {
         "description": "Ignore a tab"
     }
   },

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -25,8 +25,8 @@
         },
         "description": "Toggle fast playback"
     },
-    "toggleFastRewind": {
-        "description": "Toggle fast rewind"
+    "Rewind": {
+        "description": "Rewind"
     },
     "pauseoninactive": {
         "suggested_key": {

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -49,7 +49,7 @@
         "description": "Go to start of media"
     },
 	"ignoretab": {
-        "description": "Ignores a tab"
+        "description": "Ignore a tab"
     }
   },
   "permissions": [

--- a/options.html
+++ b/options.html
@@ -14,6 +14,7 @@
     <div><label for="disableresume"> Disable automatic resume</label><input type="checkbox" id="disableresume"></div>
     <div><label for="pauseoninactive"> Pause media on tab change and limit resume to the active and marked tabs</label><input type="checkbox" id="pauseoninactive"></div>
     <div><label for="ignoretabchange"> Ignore tab changes</label><input type="checkbox" id="ignoretabchange"></div>
+    <div><label for="pausemuted"> Pause media if muted and not visible (No native UI support)</label><input type="checkbox" id="pausemuted"></div>
     <div><label for="multipletabs"> Resume multiple tabs (old behavior)</label><input type="checkbox" id="multipletabs"></div>
     <h2>Shortcuts</h2>
     <div id="shortcuts"></div>

--- a/options.html
+++ b/options.html
@@ -14,7 +14,7 @@
     <div><label for="disableresume"> Disable automatic resume</label><input type="checkbox" id="disableresume"></div>
     <div><label for="pauseoninactive"> Pause media on tab change and limit resume to the active and marked tabs</label><input type="checkbox" id="pauseoninactive"></div>
     <div><label for="ignoretabchange"> Ignore tab changes</label><input type="checkbox" id="ignoretabchange"></div>
-    <div><label for="pausemuted"> Pause media if muted and not visible (No native UI support)</label><input type="checkbox" id="pausemuted"></div>
+    <div><label for="pausemuted"> Pause media if muted and not visible (Also supports tab mute, Not PiP)</label><input type="checkbox" id="pausemuted"></div>
     <div><label for="multipletabs"> Resume multiple tabs (old behavior)</label><input type="checkbox" id="multipletabs"></div>
     <h2>Shortcuts</h2>
     <div id="shortcuts"></div>

--- a/options.js
+++ b/options.js
@@ -22,14 +22,15 @@ chrome.permissions.onRemoved.addListener(getPermissions);
 chrome.storage.sync.get('options', result => {
     if (typeof result.options === 'object' && result.options !== null) {
         options = result.options;
-        
+	applyChanges();
     }
 });
 
 chrome.storage.onChanged.addListener(result => {
-    if (typeof result.options === 'object' && result.options !== null)
-        options = result.options.newValue
-	    applyChanges();
+    if (typeof result.options === 'object' && result.options !== null) {
+        options = result.options.newValue;
+	applyChanges();
+    }
 });
 
 function applyChanges() {

--- a/options.js
+++ b/options.js
@@ -4,7 +4,7 @@ var permissions = [];
 var options = {};
 
 // ID for each checkbox
-const supported = ['disableresume', 'pauseoninactive', 'multipletabs', 'ignoretabchange'];
+const supported = ['disableresume', 'pauseoninactive', 'multipletabs', 'ignoretabchange', 'pausemuted'];
 
 var userinput = document.getElementById('userinput');
 


### PR DESCRIPTION
- Better PiP support, Treat trusted play events as active tab.
- New shortcut, To mark a tab as ignored.
- New shortcut, Rewind media in 30 second increments.
- New option, Pause media when muted and not visible (Also supports tab mute, Not PiP due to lack of API on firefox)
- Use new event, pagehide instead of beforeunload.
